### PR TITLE
Fix quantile value prediction sampling

### DIFF
--- a/quantileppoimpl/purequantilePPO.py
+++ b/quantileppoimpl/purequantilePPO.py
@@ -65,7 +65,7 @@ class QuantileActorCriticPolicy(ActorCriticPolicy):
             n_quantiles=self.n_quantiles,
             n_basis=64,
             hidden_dim=self.mlp_extractor.latent_dim_vf,
-            device="cuda",
+            device=self.device,
         )
         self.quantile_loss = QuantileLoss()
 
@@ -73,9 +73,7 @@ class QuantileActorCriticPolicy(ActorCriticPolicy):
         features = self.extract_features(obs)
         _, latent_vf = self.mlp_extractor(features)
         B = latent_vf.shape[0]
-        batch_size = obs.size(0)
-        taus = th.rand(batch_size, self.quantile_head.n_quantiles, device=latent_vf.device)
-        taus = taus.view(1, -1, 1).expand(B, -1, -1)
+        taus = th.rand(B, self.quantile_head.n_quantiles, 1, device=latent_vf.device)
         q = self.quantile_head(latent_vf, tau=taus)  # [B, N, 1]
         v = q.mean(dim=-2).squeeze(-1)  # [B]
         return v.unsqueeze(-1)  # [B, 1]


### PR DESCRIPTION
## Summary
- ensure quantile head uses policy device
- sample tau correctly for value predictions

## Testing
- `python -m py_compile quantileppoimpl/purequantilePPO.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b2b38d124832aa5ee2d55314b9c2e